### PR TITLE
test: add unit tests for HttpExchangeClientBeanFactoryInitializationA…

### DIFF
--- a/shore-core/src/test/java/run/vexa/reactor/core/spel/DefaultEvaluationContextFactoryTest.java
+++ b/shore-core/src/test/java/run/vexa/reactor/core/spel/DefaultEvaluationContextFactoryTest.java
@@ -1,20 +1,16 @@
 package run.vexa.reactor.core.spel;
 
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Method;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * Default evaluation context factory unit test.
- * @author rained
- **/
 class DefaultEvaluationContextFactoryTest {
 
     private DefaultEvaluationContextFactory factory;
@@ -24,30 +20,77 @@ class DefaultEvaluationContextFactoryTest {
         factory = new DefaultEvaluationContextFactory();
     }
 
-
     @Test
-    void testExpandMapInjection() throws NoSuchMethodException {
-        Method method = SampleClass.class.getMethod("sampleMethod", String.class, int.class);
-        Map<String, Object> expandMap = Map.of("extraVar", "extraValue");
-        EvaluationContext context = factory.eval(method, new Object[]{"test", 123}, expandMap);
-        assertEquals("extraValue", context.lookupVariable("extraVar"));
+    void evalRegistersMethodParameters() throws Exception {
+        Method method = SampleTarget.class.getDeclaredMethod("sampleMethod", String.class, int.class);
+        EvaluationContext ctx = factory.eval(method, new Object[]{"Alice", 28}, Map.of());
+
+        StandardEvaluationContext standardContext = (StandardEvaluationContext) ctx;
+        String[] parameterNames = getCachedParameterNames(method);
+        assertNotNull(parameterNames);
+        assertEquals(2, parameterNames.length);
+        assertEquals("Alice", standardContext.lookupVariable(parameterNames[0]));
+        assertEquals(28, standardContext.lookupVariable(parameterNames[1]));
     }
 
-
     @Test
-    void testEvaluationContextProperties() {
-        StandardEvaluationContext context = (StandardEvaluationContext) factory.eval(null, null, null);
-        assertNotNull(context.getPropertyAccessors());
-        assertFalse(context.getPropertyAccessors().isEmpty());
-        assertNotNull(context.getTypeLocator());
-        assertNotNull(context.getTypeConverter());
+    void evalSkipsWhenArgsLengthMismatch() throws Exception {
+        Method method = SampleTarget.class.getDeclaredMethod("sampleMethod", String.class, int.class);
+        EvaluationContext ctx = factory.eval(method, new Object[]{"only-one"}, Map.of());
+
+        StandardEvaluationContext standardContext = (StandardEvaluationContext) ctx;
+        String[] parameterNames = getCachedParameterNames(method);
+        assertNotNull(parameterNames);
+        for (String name : parameterNames) {
+            assertNull(standardContext.lookupVariable(name));
+        }
     }
 
-    @SuppressWarnings("unused")
-    static class SampleClass {
-        public void sampleMethod(String param1, int param2) {
-            // do nothing
+    @Test
+    void evalMergesExpandMap() throws Exception {
+        Method method = SampleTarget.class.getDeclaredMethod("sampleMethod", String.class, int.class);
+        EvaluationContext ctx = factory.eval(method, new Object[]{"Alice", 28}, Map.of("extra", "value"));
+
+        StandardEvaluationContext standardContext = (StandardEvaluationContext) ctx;
+        assertEquals("value", standardContext.lookupVariable("extra"));
+    }
+
+    @Test
+    void evalWithNullMethodUsesExpandMapOnly() {
+        EvaluationContext ctx = factory.eval(null, null, Map.of("foo", "bar"));
+        StandardEvaluationContext standardContext = (StandardEvaluationContext) ctx;
+        assertEquals("bar", standardContext.lookupVariable("foo"));
+    }
+
+    @Test
+    void parameterNamesAreCached() throws Exception {
+        Method method = SampleTarget.class.getDeclaredMethod("sampleMethod", String.class, int.class);
+        factory.eval(method, new Object[]{"Alice", 28}, Map.of());
+        factory.eval(method, new Object[]{"Bob", 30}, Map.of());
+
+        String[] parameterNames = getCachedParameterNames(method);
+        assertNotNull(parameterNames);
+        assertEquals(2, parameterNames.length);
+        assertSame(parameterNames, getCachedParameterNames(method));
+        assertEquals(1, getParameterNameCacheSize());
+    }
+
+    private String[] getCachedParameterNames(Method method) {
+        @SuppressWarnings("unchecked")
+        Map<Method, String[]> cache = (Map<Method, String[]>) ReflectionTestUtils.getField(factory, "parameterNamesCache");
+        return cache != null ? cache.get(method) : null;
+    }
+
+    private int getParameterNameCacheSize() {
+        @SuppressWarnings("unchecked")
+        Map<Method, String[]> cache = (Map<Method, String[]>) ReflectionTestUtils.getField(factory, "parameterNamesCache");
+        return cache != null ? cache.size() : 0;
+    }
+
+    private static final class SampleTarget {
+        @SuppressWarnings("unused")
+        void sampleMethod(String name, int age) {
+            // no-op
         }
     }
 }
-

--- a/shore-starters/shore-http/src/test/java/run/vexa/reactor/http/aot/HttpExchangeClientBeanFactoryInitializationAotProcessorTest.java
+++ b/shore-starters/shore-http/src/test/java/run/vexa/reactor/http/aot/HttpExchangeClientBeanFactoryInitializationAotProcessorTest.java
@@ -1,0 +1,201 @@
+package run.vexa.reactor.http.aot;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.hint.ReflectionHints;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationCode;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.support.GenericApplicationContext;
+import run.vexa.reactor.http.core.HttpExchangeClientFactoryBean;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class HttpExchangeClientBeanFactoryInitializationAotProcessorTest {
+
+    private GenericApplicationContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    void returnsNullWhenNoHttpExchangeClients() {
+        context = new GenericApplicationContext();
+        context.refresh();
+
+        HttpExchangeClientBeanFactoryInitializationAotProcessor processor =
+                new HttpExchangeClientBeanFactoryInitializationAotProcessor(context);
+
+        BeanFactoryInitializationAotContribution contribution = processor.processAheadOfTime(context.getBeanFactory());
+        assertThat(contribution).isNull();
+    }
+
+    @Test
+    void returnsNullWhenBeanFactoryDoesNotMatch() {
+        registerHttpExchangeClientFactory();
+
+        HttpExchangeClientBeanFactoryInitializationAotProcessor processor =
+                new HttpExchangeClientBeanFactoryInitializationAotProcessor(context);
+
+        BeanFactoryInitializationAotContribution contribution =
+                processor.processAheadOfTime(new DefaultListableBeanFactory());
+
+        assertThat(contribution).isNull();
+    }
+
+    @Test
+    void registersHintsForReturnTypesAndRequestBodies() throws Exception {
+        registerHttpExchangeClientFactory();
+
+        RecordingProcessor processor = new RecordingProcessor(context);
+
+        BeanFactoryInitializationAotContribution contribution =
+                processor.processAheadOfTime(context.getBeanFactory());
+        assertThat(contribution).isNotNull();
+
+        RuntimeHints runtimeHints = new RuntimeHints();
+        GenerationContext generationContext = createGenerationContext(runtimeHints);
+        BeanFactoryInitializationCode initializationCode = createBeanFactoryInitializationCode();
+        contribution.applyTo(generationContext, initializationCode);
+
+        assertThat(processor.returnTypeRegistrations).contains(SampleResponse.class);
+        assertThat(processor.parameterTypeRegistrations).contains(SampleRequest.class);
+    }
+
+    private void registerHttpExchangeClientFactory() {
+        context = new GenericApplicationContext();
+        RootBeanDefinition beanDefinition = new RootBeanDefinition(HttpExchangeClientFactoryBean.class);
+        beanDefinition.getPropertyValues().add("httpExchangeClientInterface", SampleHttpClient.class);
+        context.registerBeanDefinition("sampleHttpClientFactory", beanDefinition);
+        context.refresh();
+    }
+
+    interface SampleHttpClient {
+
+        SampleResponse submit(@org.springframework.web.bind.annotation.RequestBody SampleRequest request);
+    }
+
+    static class SampleRequest {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    static class SampleResponse {
+        private String result;
+
+        public String getResult() {
+            return result;
+        }
+
+        public void setResult(String result) {
+            this.result = result;
+        }
+    }
+
+    private static final class RecordingProcessor extends HttpExchangeClientBeanFactoryInitializationAotProcessor {
+
+        private final List<Class<?>> parameterTypeRegistrations = new ArrayList<>();
+        private final List<Class<?>> returnTypeRegistrations = new ArrayList<>();
+
+        private RecordingProcessor(GenericApplicationContext context) {
+            super(context);
+        }
+
+        @Override
+        protected void registerParameterTypeHints(ReflectionHints hints, org.springframework.core.MethodParameter methodParameter) {
+            parameterTypeRegistrations.add(methodParameter.getParameterType());
+            super.registerParameterTypeHints(hints, methodParameter);
+        }
+
+        @Override
+        protected void registerReturnTypeHints(ReflectionHints hints, org.springframework.core.MethodParameter returnTypeParameter) {
+            returnTypeRegistrations.add(returnTypeParameter.getParameterType());
+            super.registerReturnTypeHints(hints, returnTypeParameter);
+        }
+    }
+
+    private static GenerationContext createGenerationContext(RuntimeHints hints) {
+        return (GenerationContext) Proxy.newProxyInstance(
+                GenerationContext.class.getClassLoader(),
+                new Class<?>[]{GenerationContext.class},
+                new GenerationContextInvocationHandler(hints));
+    }
+
+    private static BeanFactoryInitializationCode createBeanFactoryInitializationCode() {
+        return mock(BeanFactoryInitializationCode.class);
+    }
+
+    private static final class GenerationContextInvocationHandler implements InvocationHandler {
+
+        private final RuntimeHints runtimeHints;
+        private final Map<Class<?>, Object> interfaceCache = new ConcurrentHashMap<>();
+
+        private GenerationContextInvocationHandler(RuntimeHints runtimeHints) {
+            this.runtimeHints = runtimeHints;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            Object result = null;
+            String methodName = method.getName();
+            if ("getRuntimeHints".equals(methodName)) {
+                result = runtimeHints;
+            } else {
+                Class<?> returnType = method.getReturnType();
+                if (returnType.isPrimitive()) {
+                    result = primitiveDefault(returnType);
+                } else if (returnType.isInterface()) {
+                    result = interfaceCache.computeIfAbsent(returnType, GenerationContextInvocationHandler::createInterfaceProxy);
+                }
+            }
+            return result;
+        }
+
+        private static Object createInterfaceProxy(Class<?> iface) {
+            InvocationHandler handler = (p, m, a) -> {
+                Class<?> returnType = m.getReturnType();
+                return returnType.isPrimitive() ? primitiveDefault(returnType) : null;
+            };
+            return Proxy.newProxyInstance(iface.getClassLoader(), new Class<?>[]{iface}, handler);
+        }
+
+        private static Object primitiveDefault(Class<?> primitiveType) {
+            Object value;
+            switch (primitiveType.getName()) {
+                case "boolean" -> value = Boolean.FALSE;
+                case "byte" -> value = Byte.valueOf((byte) 0);
+                case "short" -> value = Short.valueOf((short) 0);
+                case "char" -> value = Character.valueOf('\0');
+                case "int" -> value = Integer.valueOf(0);
+                case "long" -> value = Long.valueOf(0L);
+                case "float" -> value = Float.valueOf(0F);
+                case "double" -> value = Double.valueOf(0D);
+                default -> value = null;
+            }
+            return value;
+        }
+    }
+}

--- a/shore-starters/shore-http/src/test/java/run/vexa/reactor/http/autoconfigure/HttpInterfaceAutoConfigurationTest.java
+++ b/shore-starters/shore-http/src/test/java/run/vexa/reactor/http/autoconfigure/HttpInterfaceAutoConfigurationTest.java
@@ -65,15 +65,22 @@ class HttpInterfaceAutoConfigurationTest {
 
         private ResolvableType currentType;
         private ResolvableType capturedTargetType;
+        private final Class<?> capturedBeanClass;
 
         private CapturingRootBeanDefinition(Class<?> beanClass) {
             super(beanClass);
+            this.capturedBeanClass = beanClass;
             this.currentType = ResolvableType.forClass(beanClass);
         }
 
         @Override
         public ResolvableType getResolvableType() {
             return currentType;
+        }
+
+        @Override
+        public Class<?> getBeanClass() {
+            return this.capturedBeanClass;
         }
 
         @Override


### PR DESCRIPTION
…otProcessor and enhance HttpInterfaceAutoConfigurationTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded evaluation context tests covering parameter name caching, argument-length handling, and map expansion merging.
  - Added AOT processing tests for HTTP clients to verify runtime hint registration for request and response types.
  - Improved auto-configuration test coverage with enhanced bean class capturing to validate correct class resolution during setup.
  - Removed outdated tests and replaced them with more focused scenarios to better reflect current behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->