### PR TITLE
test: add unit tests for HttpExchangeClientScannerRegistrarConfigurat…

### DIFF
--- a/shore-starters/shore-http/src/test/java/run/vexa/reactor/http/autoconfigure/HttpExchangeClientScannerRegistrarConfigurationTest.java
+++ b/shore-starters/shore-http/src/test/java/run/vexa/reactor/http/autoconfigure/HttpExchangeClientScannerRegistrarConfigurationTest.java
@@ -1,0 +1,34 @@
+package run.vexa.reactor.http.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import run.vexa.reactor.http.core.HttpExchangeClientFactoryBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpExchangeClientScannerRegistrarConfigurationTest {
+
+    @Test
+    void registersScannerRegistrarWhenFactoryBeanMissing() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            AutoConfigurationPackages.register(context, "run.vexa.reactor.http.testclients.scanner");
+            context.register(HttpExchangeClientScannerRegistrarConfiguration.class);
+            context.refresh();
+
+            assertThat(context.containsBean("basicScanHttpClient")).isTrue();
+        }
+    }
+
+    @Test
+    void backsOffWhenFactoryBeanAlreadyPresent() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            AutoConfigurationPackages.register(context, "run.vexa.reactor.http.testclients.scanner");
+            context.registerBean(HttpExchangeClientFactoryBean.class, () -> new HttpExchangeClientFactoryBean());
+            context.register(HttpExchangeClientScannerRegistrarConfiguration.class);
+            context.refresh();
+
+            assertThat(context.containsBean("basicScanHttpClient")).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
…ion and enhance HttpInterfaceAutoConfigurationTest with new test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded test coverage for HTTP client auto-configuration.
  - Validates conditional registration behavior when a factory bean is present or absent.
  - Verifies per-call instance creation for load-balancer filter functions.
  - Confirms presence and creation of the AOT processor in an application context.
  - Improves reliability, prevents unintended bean creation, and increases confidence in startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->